### PR TITLE
Remove trailing whitespace from LESS output

### DIFF
--- a/app/controllers/styles_controller.rb
+++ b/app/controllers/styles_controller.rb
@@ -32,7 +32,7 @@ class StylesController < ApplicationController
 
 // Grays
 @black:                 #{@colors[6] || '#000'};
-@grayDark:              #{@colors[5] || '##222'}; 
+@grayDark:              #{@colors[5] || '##222'};
 @grayDarker:            darken(@grayDark, 10%);
 @gray:                  #{@colors[3] || '#555'};
 @grayLight:             #{@colors[2] || '#999'};
@@ -112,7 +112,7 @@ class StylesController < ApplicationController
 // Fluid grid
 @fluidGridColumnWidth:    6.382978723%;
 @fluidGridGutterWidth:    2.127659574%;
-      
+
 #{Lavish::Application::BOOTSTRAP}
     }
   end


### PR DESCRIPTION
I removed trailing space in two places in the LESS output. I've left trailing whitespaces in the actual ruby file, as I wasn't sure if there was some style guide you were following. MacVim also added a newline at the end - I hope you don't mind.
